### PR TITLE
fix: update footer address and improve route chunk reload logic

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -50,7 +50,7 @@ const Footer = () => {
           </div>
           <div className="footer-contactUs">
             <h3>Contact us</h3>
-            <p>12, Oshodi APAPA expressway, Umunze house, Coconut, Lagos</p>
+            <p>Flat 4, 6 Yusuf Olorinde Street Olodi Apapa Lagos</p>
             <h5>
               +234 913 1701630 <br />
               +234 815 8882242

--- a/src/utils/routePrefetch.jsx
+++ b/src/utils/routePrefetch.jsx
@@ -55,18 +55,36 @@ export function prefetchCommonRoutes() {
   ]);
 }
 
-let hasRefreshed = false;
+const RELOAD_FLAG = "__routePrefetchReloaded";
+
+function hasReloadedOnce() {
+  try {
+    return sessionStorage.getItem(RELOAD_FLAG) === "1";
+  } catch (error) {
+    return false;
+  }
+}
+
+function markReloaded() {
+  try {
+    sessionStorage.setItem(RELOAD_FLAG, "1");
+  } catch (error) {
+    // ignore storage errors
+  }
+}
 
 export function safeLazy(importFn) {
   return lazy(() =>
     importFn().catch((error) => {
-      if (!hasRefreshed) {
-        hasRefreshed = true;
+      console.error("Route chunk failed to load:", error);
+
+      if (typeof window !== "undefined" && !hasReloadedOnce()) {
+        markReloaded();
         window.location.reload();
       }
 
       return {
-        default: () => <div>Something went wrong.</div>,
+        default: () => <div>Something went wrong. Please refresh the page.</div>,
       };
     }),
   );


### PR DESCRIPTION
## Summary
- Updated contact address in Footer to "Flat 4, 6 Yusuf Olorinde Street Olodi Apapa Lagos"
- Replaced module-level `hasRefreshed` flag in `safeLazy` with `sessionStorage`-backed tracking so the reload guard persists correctly across page reloads
- Added `console.error` logging when a route chunk fails to load
- Improved fallback error message to instruct the user to refresh

## Test plan
- [x] Visit the footer and confirm the new address is displayed
- [x] Simulate a chunk load failure and verify the page reloads once, not in a loop
- [x] Confirm the fallback "Something went wrong. Please refresh the page." message appears after the one-time reload